### PR TITLE
feat(resources): new ResourceFilter lambda expression to filter resource expansion

### DIFF
--- a/.cursor/agents/opsx-research.md
+++ b/.cursor/agents/opsx-research.md
@@ -1,0 +1,24 @@
+---
+name: opsx-research
+description: Use proactively whenever research is needed before planning, proposing, designing, specifying, or implementing. Delegates research to the knowledge-research skill and returns only concise outputs and source paths.
+model: inherit
+---
+You are a research wrapper subagent.
+
+Your job is to execute project research by delegating to the existing skill:
+`knowledge-research/SKILL.md`
+
+Workflow:
+1. Read the skill file first.
+2. Execute the skill in the appropriate mode (SEARCH, CODEBASE, ADD, or CONVERT).
+3. Prefer staged knowledge outputs over long conversational notes.
+4. Return only:
+   - direct answer summary (concise),
+   - files/folders created or used,
+   - staged entries added/updated in `openspec/knowledge.staging.md`,
+   - recommended knowledge documents to preload for downstream tasks.
+
+Constraints:
+- Keep this agent focused on research only.
+- Do not implement product code changes unless explicitly requested.
+- For complex topics, prioritize structured staged artifacts that other agents can consume.

--- a/.cursor/commands/opsx-apply.md
+++ b/.cursor/commands/opsx-apply.md
@@ -1,0 +1,152 @@
+---
+name: /opsx-apply
+id: opsx-apply
+category: Workflow
+description: Implement tasks from an OpenSpec change (Experimental)
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - Context file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read the files listed in `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.cursor/commands/opsx-archive.md
+++ b/.cursor/commands/opsx-archive.md
@@ -1,0 +1,157 @@
+---
+name: /opsx-archive
+id: opsx-archive
+category: Workflow
+description: Archive a completed change in the experimental workflow
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** openspec/changes/archive/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.cursor/commands/opsx-explore.md
+++ b/.cursor/commands/opsx-explore.md
@@ -1,0 +1,173 @@
+---
+name: /opsx-explore
+id: opsx-explore
+category: Workflow
+description: "Enter explore mode - think through ideas, investigate problems, clarify requirements"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│   ┌────────┐         ┌────────┐        │
+│   │ State  │────────▶│ State  │        │
+│   │   A    │         │   B    │        │
+│   └────────┘         └────────┘        │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+   | Insight Type | Where to Capture |
+   |--------------|------------------|
+   | New requirement discovered | `specs/<capability>/spec.md` |
+   | Requirement changed | `specs/<capability>/spec.md` |
+   | Design decision made | `design.md` |
+   | Scope changed | `proposal.md` |
+   | New work identified | `tasks.md` |
+   | Assumption invalidated | Relevant artifact |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.cursor/commands/opsx-propose.md
+++ b/.cursor/commands/opsx-propose.md
@@ -1,0 +1,106 @@
+---
+name: /opsx-propose
+id: opsx-propose
+category: Workflow
+description: Propose a new change - create it and generate all artifacts in one step
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.cursor/skills/openspec-apply-change/SKILL.md
+++ b/.cursor/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - Context file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read the files listed in `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.cursor/skills/openspec-archive-change/SKILL.md
+++ b/.cursor/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.cursor/skills/openspec-explore/SKILL.md
+++ b/.cursor/skills/openspec-explore/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│   ┌────────┐         ┌────────┐        │
+│   │ State  │────────▶│ State  │        │
+│   │   A    │         │   B    │        │
+│   └────────┘         └────────┘        │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+   | Insight Type | Where to Capture |
+   |--------------|------------------|
+   | New requirement discovered | `specs/<capability>/spec.md` |
+   | Requirement changed | `specs/<capability>/spec.md` |
+   | Design decision made | `design.md` |
+   | Scope changed | `proposal.md` |
+   | New work identified | `tasks.md` |
+   | Assumption invalidated | Relevant artifact |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │         CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.cursor/skills/openspec-propose/SKILL.md
+++ b/.cursor/skills/openspec-propose/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/autoscaler/config.yml.example
+++ b/autoscaler/config.yml.example
@@ -145,6 +145,23 @@ Resources:
   - Resources:
       example_sql_database:
         ResourceId: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-example-databases/providers/Microsoft.Sql/servers/sqlexample-server/databases/*"
+        # Optional: filter wildcard-expanded databases using a C# lambda expression.
+        # ResourceFilterContext exposes ResourceName (string), Tags (IDictionary<string,string>),
+        # and Resource (the raw ARM object; member access resolves at runtime via Dynamic LINQ).
+        #
+        # Azure SQL Database Sku.Name values:
+        #   DTU standalone : "Basic" | "Standard" | "Premium"          (Sku.Family = null)
+        #   DTU pooled     : "ElasticPool"                              (Sku.Family = null, pool-level metrics only)
+        #   vCore          : "GeneralPurpose" | "BusinessCritical" | "Hyperscale"  (Sku.Family = "Gen5" / "Fsv2" / …)
+        #
+        # Include only standalone DTU databases (Basic, Standard, Premium):
+        # ResourceFilter: "(r) => r.Resource.Data.Sku.Name == \"Basic\" || r.Resource.Data.Sku.Name == \"Standard\" || r.Resource.Data.Sku.Name == \"Premium\""
+        #
+        # Include only vCore databases:
+        # ResourceFilter: "(r) => r.Resource.Data.Sku.Family != null"
+        #
+        # Include only databases tagged env=prod:
+        # ResourceFilter: "(r) => r.Tags.ContainsKey(\"env\") && r.Tags[\"env\"] == \"prod\""
     Frequency: 5m
     WhatIf: false
     Enabled: true

--- a/autoscaler/configuration/Configuration.cs
+++ b/autoscaler/configuration/Configuration.cs
@@ -66,6 +66,23 @@ namespace poolautoscaler.configuration
 
                 resource.FrequencyParsed = DurationParser.ParseDuration(resource.Frequency);
 
+                if (resource.Resources != null)
+                {
+                    foreach (var resourceInstance in resource.Resources.Values)
+                    {
+                        if (!string.IsNullOrEmpty(resourceInstance.ResourceFilter))
+                        {
+                            resourceInstance.ResourceFilterExpression =
+                                (Func<ResourceFilterContext, bool>)ExpressionParserUtils.ParseExpression(
+                                    resourceInstance.ResourceFilter,
+                                    "r",
+                                    typeof(ResourceFilterContext),
+                                    typeof(bool),
+                                    1);
+                        }
+                    }
+                }
+
                 if (resource.CustomMetrics != null)
                 {
                     foreach (var customMetric in resource.CustomMetrics)

--- a/autoscaler/configuration/ResourceFilterContext.cs
+++ b/autoscaler/configuration/ResourceFilterContext.cs
@@ -1,0 +1,29 @@
+namespace poolautoscaler.configuration
+{
+    /// <summary>
+    /// Context passed to a <see cref="ResourceInstance.ResourceFilter"/> lambda expression.
+    /// Provides the resource name, Azure tags, and the raw ARM resource object.
+    ///
+    /// Resource-type-specific properties are accessed directly via <see cref="Resource"/>
+    /// using the same Dynamic LINQ member-access pattern as <c>CustomMetricDataContext.Resource</c>.
+    ///
+    /// Example filter (standalone DTU SQL databases only):
+    /// <code>
+    /// (r) => r.Resource.Data.Sku.Family == null &amp;&amp; r.Resource.Data.Sku.Name != "ElasticPool"
+    /// </code>
+    /// </summary>
+    public class ResourceFilterContext
+    {
+        /// <summary>The name of the resource (database name, pool name, share name, etc.).</summary>
+        public string ResourceName { get; set; }
+
+        /// <summary>Azure resource tags at expansion time. Empty dictionary if the resource has no tags.</summary>
+        public IDictionary<string, string> Tags { get; set; } = new Dictionary<string, string>();
+
+        /// <summary>
+        /// The raw ARM resource object (e.g. <c>SqlDatabaseResource</c>, <c>ContainerServiceAgentPoolResource</c>).
+        /// Dynamic LINQ resolves member access against the actual runtime type.
+        /// </summary>
+        public object Resource { get; set; }
+    }
+}

--- a/autoscaler/configuration/ResourceInstance.cs
+++ b/autoscaler/configuration/ResourceInstance.cs
@@ -16,5 +16,22 @@ namespace poolautoscaler.configuration
         ///   - PoolId: Agent pool ID to monitor for queue metrics.
         /// </summary>
         public Dictionary<string, string> Settings { get; set; }
+
+        /// <summary>
+        /// Optional C# lambda expression compiled to <c>Func&lt;ResourceFilterContext, bool&gt;</c> at startup.
+        /// When set, only wildcard-expanded resources for which the expression returns <c>true</c> are included
+        /// in the discovered resource set. Non-wildcard (literal) resource IDs are always included.
+        ///
+        /// Example — standalone DTU SQL databases only:
+        /// <code>
+        /// ResourceFilter: "(r) => r.Resource.Data.Sku.Family == null &amp;&amp; r.Resource.Data.Sku.Name != \"ElasticPool\""
+        /// </code>
+        /// Access resource-type-specific properties via <c>r.Resource</c> (Dynamic LINQ resolves members
+        /// against the actual runtime type). Use <c>r.Tags</c> for tag-based filtering.
+        /// </summary>
+        public string ResourceFilter { get; set; }
+
+        /// <summary>Compiled form of <see cref="ResourceFilter"/>. Populated by <see cref="Configuration.PrepareAndValidate"/>.</summary>
+        public Func<ResourceFilterContext, bool> ResourceFilterExpression { get; set; }
     }
 }

--- a/autoscaler/resourcemanagement/Dto/ExpandedResource.cs
+++ b/autoscaler/resourcemanagement/Dto/ExpandedResource.cs
@@ -1,0 +1,20 @@
+using poolautoscaler.configuration;
+
+namespace poolautoscaler.resourcemanagement.Dto
+{
+    /// <summary>
+    /// Result of wildcard resource expansion: a resolved resource ID paired with the filter context
+    /// built from the ARM data already fetched during expansion.
+    /// </summary>
+    public class ExpandedResource
+    {
+        /// <summary>The fully resolved Azure resource ID.</summary>
+        public string ResourceId { get; set; }
+
+        /// <summary>
+        /// Filter context populated from the ARM resource data. Null for non-wildcard (literal) resource IDs,
+        /// in which case <see cref="ResourceInstance.ResourceFilter"/> is not evaluated and the resource is always included.
+        /// </summary>
+        public ResourceFilterContext? Context { get; set; }
+    }
+}

--- a/autoscaler/resourcemanagement/IResourceStateFactory.cs
+++ b/autoscaler/resourcemanagement/IResourceStateFactory.cs
@@ -1,6 +1,7 @@
 using Azure.ResourceManager;
 using Microsoft.Extensions.Logging;
 using poolautoscaler.configuration;
+using poolautoscaler.resourcemanagement.Dto;
 
 namespace poolautoscaler.resourcemanagement
 {
@@ -11,15 +12,17 @@ namespace poolautoscaler.resourcemanagement
     public interface IResourceStateFactory
     {
         /// <summary>
-        /// Expands a resource ID that may contain wildcards into a dictionary of key to resource ID.
+        /// Expands a resource ID that may contain wildcards into a dictionary of key to <see cref="ExpandedResource"/>.
+        /// Each entry carries the resolved resource ID and a <see cref="ResourceFilterContext"/> built from the ARM data
+        /// fetched during expansion. For non-wildcard (literal) resource IDs the context is <c>null</c>.
         /// </summary>
         /// <param name="client">The ARM client.</param>
         /// <param name="key">The key for the resource entry.</param>
         /// <param name="resourceId">The resource ID or wildcard pattern.</param>
         /// <param name="logger">The logger.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>A dictionary of key to expanded resource IDs.</returns>
-        Task<Dictionary<string, string>> ExpandResourcesAsync(
+        /// <returns>A dictionary of key to <see cref="ExpandedResource"/>.</returns>
+        Task<Dictionary<string, ExpandedResource>> ExpandResourcesAsync(
             ArmClient client,
             string key,
             string resourceId,

--- a/autoscaler/resourcemanagement/ResourceManager.cs
+++ b/autoscaler/resourcemanagement/ResourceManager.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using Microsoft.Extensions.Logging;
 using poolautoscaler.configuration;
+using poolautoscaler.resourcemanagement.Dto;
 
 namespace poolautoscaler.resourcemanagement
 {
@@ -105,7 +106,7 @@ namespace poolautoscaler.resourcemanagement
 
                 foreach (var resourceInstance in resource.Resources)
                 {
-                    Dictionary<string, string> expandedResourceIds;
+                    Dictionary<string, ExpandedResource> expandedResourceIds;
                     try
                     {
                         expandedResourceIds = await this.resourceStateFactory.ExpandResourcesAsync(
@@ -131,22 +132,40 @@ namespace poolautoscaler.resourcemanagement
                         continue;
                     }
 
+                    var filter = resourceInstance.Value.ResourceFilterExpression;
+                    int instanceDiscovered = expandedResourceIds.Count;
+                    int instanceFiltered = 0;
+                    int instanceAdded = 0;
+
                     foreach (var expandedResourceId in expandedResourceIds)
                     {
                         resourceInstance.Value.Id = resourceInstance.Key;
+
+                        if (filter != null && expandedResourceId.Value.Context != null
+                            && !filter(expandedResourceId.Value.Context))
+                        {
+                            this.logger.LogDebug(
+                                "Resource '{Name}' excluded by ResourceFilter on '{InstanceKey}'.",
+                                expandedResourceId.Value.Context.ResourceName,
+                                resourceInstance.Key);
+                            instanceFiltered++;
+                            continue;
+                        }
+
+                        var resourceId = expandedResourceId.Value.ResourceId;
                         discoveredResources.Add(expandedResourceId.Key);
 
                         if (this.resources.ContainsKey(expandedResourceId.Key))
                         {
-                            this.logger.LogTrace("Keeping existing resource: {Id}", expandedResourceId.Value);
+                            this.logger.LogTrace("Keeping existing resource: {Id}", resourceId);
                         }
                         else
                         {
-                            this.logger.LogInformation("Adding new resource {Key}: {Id}", expandedResourceId.Key, expandedResourceId.Value);
+                            this.logger.LogInformation("Adding new resource {Key}: {Id}", expandedResourceId.Key, resourceId);
 
                             var resourceLogger = this.logFactory.CreateLogger(expandedResourceId.Key);
                             var state = this.resourceStateFactory.Create(
-                                expandedResourceId.Value,
+                                resourceId,
                                 resourceLogger,
                                 resource,
                                 resourceInstance.Value);
@@ -156,7 +175,18 @@ namespace poolautoscaler.resourcemanagement
                                 string.Join(", ", state.ResourceParts.Select((i) => $"{i.Key}={i.Value}")));
                             this.resources[expandedResourceId.Key] = state;
                             addedResources++;
+                            instanceAdded++;
                         }
+                    }
+
+                    if (filter != null)
+                    {
+                        this.logger.LogInformation(
+                            "ResourceFilter '{InstanceKey}': {Discovered} discovered, {Filtered} filtered out, {Added} added.",
+                            resourceInstance.Key,
+                            instanceDiscovered,
+                            instanceFiltered,
+                            instanceAdded);
                     }
                 }
             }

--- a/autoscaler/resourcemanagement/ResourceStateFactory.cs
+++ b/autoscaler/resourcemanagement/ResourceStateFactory.cs
@@ -3,6 +3,7 @@ using Azure.ResourceManager;
 using Microsoft.Extensions.Logging;
 using poolautoscaler.configuration;
 using poolautoscaler.metrics;
+using poolautoscaler.resourcemanagement.Dto;
 using poolautoscaler.resources.AksNodePool;
 using poolautoscaler.resources.AzureDevops;
 using poolautoscaler.resources.FabricCapacity;
@@ -100,7 +101,7 @@ namespace poolautoscaler.resourcemanagement
         }
 
         /// <inheritdoc />
-        public async Task<Dictionary<string, string>> ExpandResourcesAsync(ArmClient client, string key, string resourceId, ILogger logger, CancellationToken cancellationToken = default)
+        public async Task<Dictionary<string, ExpandedResource>> ExpandResourcesAsync(ArmClient client, string key, string resourceId, ILogger logger, CancellationToken cancellationToken = default)
         {
             // Make sure these are ordered from most specific to least specific
             Match match;
@@ -122,10 +123,9 @@ namespace poolautoscaler.resourcemanagement
                 return await StorageFileShareResourceStateHelper.ExpandFileShareWildcard(client, key, resourceId, logger, cancellationToken);
             }
 
-            // Fabric capacities don't support expansion (no wildcards)
-
-            var result = new Dictionary<string, string>();
-            result.Add(key, resourceId);
+            // Fabric capacities and other non-wildcard resources: context is null (filter is skipped)
+            var result = new Dictionary<string, ExpandedResource>();
+            result.Add(key, new ExpandedResource { ResourceId = resourceId, Context = null });
             return result;
         }
 

--- a/autoscaler/resources/AksNodePool/AksNodePoolResourceStateHelper.cs
+++ b/autoscaler/resources/AksNodePool/AksNodePoolResourceStateHelper.cs
@@ -2,7 +2,9 @@ using Azure.Core;
 using Azure.ResourceManager;
 using Azure.ResourceManager.ContainerService;
 using Microsoft.Extensions.Logging;
+using poolautoscaler.configuration;
 using poolautoscaler.resourcemanagement;
+using poolautoscaler.resourcemanagement.Dto;
 
 namespace poolautoscaler.resources.AksNodePool
 {
@@ -20,9 +22,9 @@ namespace poolautoscaler.resources.AksNodePool
         /// <param name="logger">The logger.</param>
         /// <param name="stoppingToken">Cancellation token.</param>
         /// <returns>A dictionary of key to expanded resource IDs.</returns>
-        public static async Task<Dictionary<string, string>> ExpandNodePoolWildcard(ArmClient client, string key, string resourceId, ILogger logger, CancellationToken stoppingToken)
+        public static async Task<Dictionary<string, ExpandedResource>> ExpandNodePoolWildcard(ArmClient client, string key, string resourceId, ILogger logger, CancellationToken stoppingToken)
         {
-            var result = new Dictionary<string, string>();
+            var result = new Dictionary<string, ExpandedResource>();
 
             var match = ResourceStateFactory.AksNodePool.Match(resourceId);
             if (!match.Success)
@@ -34,7 +36,7 @@ namespace poolautoscaler.resources.AksNodePool
             var pattern = ResourceStateFactory.GetResourcePattern(nodePoolName);
             if (pattern == null)
             {
-                result.Add(key, resourceId);
+                result.Add(key, new ExpandedResource { ResourceId = resourceId, Context = null });
                 return result;
             }
 
@@ -51,7 +53,13 @@ namespace poolautoscaler.resources.AksNodePool
                 if (pattern.IsMatch(nodePool.Data.Name))
                 {
                     var expandedId = $"{clusterId}/agentPools/{nodePool.Data.Name}";
-                    result.Add(key + "_" + nodePool.Data.Name, expandedId);
+                    var context = new ResourceFilterContext
+                    {
+                        ResourceName = nodePool.Data.Name,
+                        Tags = nodePool.Data.Tags ?? new Dictionary<string, string>(),
+                        Resource = nodePool,
+                    };
+                    result.Add(key + "_" + nodePool.Data.Name, new ExpandedResource { ResourceId = expandedId, Context = context });
                     logger.LogDebug("Expanded AKS node pool: {0}", expandedId);
                 }
             }

--- a/autoscaler/resources/MsSqlDatabase/MsSqlDatabaseResourceStateHelper.cs
+++ b/autoscaler/resources/MsSqlDatabase/MsSqlDatabaseResourceStateHelper.cs
@@ -3,7 +3,9 @@ using Azure.ResourceManager;
 using Azure.ResourceManager.Sql;
 using Azure.ResourceManager.Sql.Models;
 using Microsoft.Extensions.Logging;
+using poolautoscaler.configuration;
 using poolautoscaler.resourcemanagement;
+using poolautoscaler.resourcemanagement.Dto;
 
 namespace poolautoscaler.resources.MsSqlDatabase
 {
@@ -298,16 +300,16 @@ namespace poolautoscaler.resources.MsSqlDatabase
             throw new Exception("No tier can accomodate DTU and/or capacity request.");
         }
 
-        /// <summary>Expands a SQL database resource ID that may contain wildcards into concrete resource IDs.</summary>
+        /// <summary>Expands a SQL database resource ID that may contain wildcards into concrete resource IDs with filter contexts.</summary>
         /// <param name="client">The ARM client.</param>
         /// <param name="key">The key for the resource entry.</param>
         /// <param name="resourceId">The resource ID or wildcard pattern.</param>
         /// <param name="logger">The logger.</param>
         /// <param name="stoppingToken">Cancellation token.</param>
-        /// <returns>A dictionary of key to expanded resource IDs.</returns>
-        public static async Task<Dictionary<string, string>> ExpandSqlDatabaseWildcard(ArmClient client, string key, string resourceId, ILogger logger, CancellationToken stoppingToken)
+        /// <returns>A dictionary of key to <see cref="ExpandedResource"/>.</returns>
+        public static async Task<Dictionary<string, ExpandedResource>> ExpandSqlDatabaseWildcard(ArmClient client, string key, string resourceId, ILogger logger, CancellationToken stoppingToken)
         {
-            var result = new Dictionary<string, string>();
+            var result = new Dictionary<string, ExpandedResource>();
             var match = ResourceStateFactory.SqlDatabase.Match(resourceId);
             if (!match.Success)
             {
@@ -318,7 +320,7 @@ namespace poolautoscaler.resources.MsSqlDatabase
             var pattern = ResourceStateFactory.GetResourcePattern(databaseName);
             if (pattern == null)
             {
-                result.Add(key, resourceId);
+                result.Add(key, new ExpandedResource { ResourceId = resourceId, Context = null });
                 return result;
             }
 
@@ -336,7 +338,13 @@ namespace poolautoscaler.resources.MsSqlDatabase
                 if (pattern.IsMatch(database.Data.Name))
                 {
                     var expandedId = $"{serverId}/databases/{database.Data.Name}";
-                    result.Add(key + "_" + database.Data.Name, expandedId);
+                    var context = new ResourceFilterContext
+                    {
+                        ResourceName = database.Data.Name,
+                        Tags = database.Data.Tags ?? new Dictionary<string, string>(),
+                        Resource = database,
+                    };
+                    result.Add(key + "_" + database.Data.Name, new ExpandedResource { ResourceId = expandedId, Context = context });
                     logger.LogDebug("Expanded SQL database: {0}", expandedId);
                 }
             }

--- a/autoscaler/resources/MssqlElasticPool/MssqlElasticPoolResourceStateHelper.cs
+++ b/autoscaler/resources/MssqlElasticPool/MssqlElasticPoolResourceStateHelper.cs
@@ -3,7 +3,9 @@ using Azure.ResourceManager;
 using Azure.ResourceManager.Sql;
 using Azure.ResourceManager.Sql.Models;
 using Microsoft.Extensions.Logging;
+using poolautoscaler.configuration;
 using poolautoscaler.resourcemanagement;
+using poolautoscaler.resourcemanagement.Dto;
 
 namespace poolautoscaler.resources.MssqlElasticPool
 {
@@ -126,16 +128,16 @@ namespace poolautoscaler.resources.MssqlElasticPool
             }
         }
 
-        /// <summary>Expands an elastic pool resource ID that may contain wildcards into concrete resource IDs.</summary>
+        /// <summary>Expands an elastic pool resource ID that may contain wildcards into concrete resource IDs with filter contexts.</summary>
         /// <param name="client">The ARM client.</param>
         /// <param name="key">The key for the resource entry.</param>
         /// <param name="resourceId">The resource ID or wildcard pattern.</param>
         /// <param name="logger">The logger.</param>
         /// <param name="stoppingToken">Cancellation token.</param>
-        /// <returns>A dictionary of key to expanded resource IDs.</returns>
-        public static async Task<Dictionary<string, string>> ExpandElasticPoolWildcard(ArmClient client, string key, string resourceId, ILogger logger, CancellationToken stoppingToken)
+        /// <returns>A dictionary of key to <see cref="ExpandedResource"/>.</returns>
+        public static async Task<Dictionary<string, ExpandedResource>> ExpandElasticPoolWildcard(ArmClient client, string key, string resourceId, ILogger logger, CancellationToken stoppingToken)
         {
-            var result = new Dictionary<string, string>();
+            var result = new Dictionary<string, ExpandedResource>();
             var match = ResourceStateFactory.ElasticPools.Match(resourceId);
             if (!match.Success)
             {
@@ -146,7 +148,7 @@ namespace poolautoscaler.resources.MssqlElasticPool
             var pattern = ResourceStateFactory.GetResourcePattern(elasticPoolName);
             if (pattern == null)
             {
-                result.Add(key, resourceId);
+                result.Add(key, new ExpandedResource { ResourceId = resourceId, Context = null });
                 return result;
             }
 
@@ -159,7 +161,13 @@ namespace poolautoscaler.resources.MssqlElasticPool
                 if (pattern.IsMatch(elasticPool.Data.Name))
                 {
                     var expandedId = $"{serverId}/elasticPools/{elasticPool.Data.Name}";
-                    result.Add(key + "_" + elasticPool.Data.Name, expandedId);
+                    var context = new ResourceFilterContext
+                    {
+                        ResourceName = elasticPool.Data.Name,
+                        Tags = elasticPool.Data.Tags ?? new Dictionary<string, string>(),
+                        Resource = elasticPool,
+                    };
+                    result.Add(key + "_" + elasticPool.Data.Name, new ExpandedResource { ResourceId = expandedId, Context = context });
                     logger.LogDebug("Expanded elastic pool: {0}", expandedId);
                 }
             }

--- a/autoscaler/resources/StorageFileShare/StorageFileShareResourceStateHelper.cs
+++ b/autoscaler/resources/StorageFileShare/StorageFileShareResourceStateHelper.cs
@@ -2,7 +2,9 @@ using Azure.Core;
 using Azure.ResourceManager;
 using Azure.ResourceManager.Storage;
 using Microsoft.Extensions.Logging;
+using poolautoscaler.configuration;
 using poolautoscaler.resourcemanagement;
+using poolautoscaler.resourcemanagement.Dto;
 
 namespace poolautoscaler.resources.StorageFileShare
 {
@@ -53,9 +55,9 @@ namespace poolautoscaler.resources.StorageFileShare
         /// <param name="logger">The logger.</param>
         /// <param name="stoppingToken">Cancellation token.</param>
         /// <returns>A dictionary of key to expanded resource IDs.</returns>
-        public static async Task<Dictionary<string, string>> ExpandFileShareWildcard(ArmClient client, string key, string resourceId, ILogger logger, CancellationToken stoppingToken)
+        public static async Task<Dictionary<string, ExpandedResource>> ExpandFileShareWildcard(ArmClient client, string key, string resourceId, ILogger logger, CancellationToken stoppingToken)
         {
-            var result = new Dictionary<string, string>();
+            var result = new Dictionary<string, ExpandedResource>();
 
             var match = ResourceStateFactory.FileShare.Match(resourceId);
             if (!match.Success)
@@ -67,7 +69,7 @@ namespace poolautoscaler.resources.StorageFileShare
             var pattern = ResourceStateFactory.GetResourcePattern(fileShareName);
             if (pattern == null)
             {
-                result.Add(key, resourceId);
+                result.Add(key, new ExpandedResource { ResourceId = resourceId, Context = null });
                 return result;
             }
 
@@ -84,7 +86,13 @@ namespace poolautoscaler.resources.StorageFileShare
                 if (pattern.IsMatch(fileShare.Data.Name))
                 {
                     var expandedId = $"{storageAccountId}/fileServices/default/shares/{fileShare.Data.Name}";
-                    result.Add(key + "_" + fileShare.Data.Name, expandedId);
+                    var context = new ResourceFilterContext
+                    {
+                        ResourceName = fileShare.Data.Name,
+                        Tags = new Dictionary<string, string>(),
+                        Resource = fileShare,
+                    };
+                    result.Add(key + "_" + fileShare.Data.Name, new ExpandedResource { ResourceId = expandedId, Context = context });
                     logger.LogDebug("Expanded file share: {0}", expandedId);
                 }
             }

--- a/autoscaler/utils/MyCustomTypeProvider.cs
+++ b/autoscaler/utils/MyCustomTypeProvider.cs
@@ -1,4 +1,5 @@
 using System.Linq.Dynamic.Core.CustomTypeProviders;
+using poolautoscaler.configuration;
 using poolautoscaler.metrics.Dto;
 using poolautoscaler.strategies.Dto;
 
@@ -18,6 +19,7 @@ namespace poolautoscaler.utils
                 typeof(CustomMetricHelpers),
                 typeof(VmssMetricView),
                 typeof(VmssSkuView),
+                typeof(ResourceFilterContext),
             }.ToHashSet();
     }
 }

--- a/autoscalertests/ConfigurationResourceFilterTests.cs
+++ b/autoscalertests/ConfigurationResourceFilterTests.cs
@@ -1,0 +1,93 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using poolautoscaler.configuration;
+
+namespace poolautoscaler.tests
+{
+    /// <summary>
+    /// Tests for ResourceFilter compilation in Configuration.PrepareAndValidate (task 7.1).
+    /// </summary>
+    public class ConfigurationResourceFilterTests
+    {
+        private readonly ILogger logger = new Mock<ILogger>().Object;
+
+        [Fact]
+        public void PrepareAndValidate_ValidResourceFilter_CompilesWithoutError()
+        {
+            var config = BuildConfig("(r) => r.ResourceName != \"master\"");
+
+            config.PrepareAndValidate(this.logger);
+
+            var instance = config.Resources[0].Resources["db1"];
+            Assert.NotNull(instance.ResourceFilterExpression);
+        }
+
+        [Fact]
+        public void PrepareAndValidate_ValidResourceFilter_ExpressionIsCallable()
+        {
+            var config = BuildConfig("(r) => r.ResourceName != \"master\"");
+            config.PrepareAndValidate(this.logger);
+
+            var expr = config.Resources[0].Resources["db1"].ResourceFilterExpression!;
+            var ctx = new ResourceFilterContext { ResourceName = "mydb", Tags = new Dictionary<string, string>(), Resource = new object() };
+
+            Assert.True(expr(ctx));
+        }
+
+        [Fact]
+        public void PrepareAndValidate_InvalidResourceFilter_ThrowsDescriptiveError()
+        {
+            var config = BuildConfig("(r) => r.DoesNotExist");
+
+            var ex = Assert.Throws<Exception>(() => config.PrepareAndValidate(this.logger));
+            Assert.Contains("r.DoesNotExist", ex.Message);
+        }
+
+        [Fact]
+        public void PrepareAndValidate_NullResourceFilter_LeavesExpressionNull()
+        {
+            var config = BuildConfig(null);
+
+            config.PrepareAndValidate(this.logger);
+
+            var instance = config.Resources[0].Resources["db1"];
+            Assert.Null(instance.ResourceFilterExpression);
+        }
+
+        [Fact]
+        public void PrepareAndValidate_EmptyResourceFilter_LeavesExpressionNull()
+        {
+            var config = BuildConfig(string.Empty);
+
+            config.PrepareAndValidate(this.logger);
+
+            var instance = config.Resources[0].Resources["db1"];
+            Assert.Null(instance.ResourceFilterExpression);
+        }
+
+        private static Configuration BuildConfig(string? resourceFilter)
+        {
+            return new Configuration
+            {
+                DefaultResourceFrequency = "4m",
+                ResourceDiscoveryFrequency = "1h",
+                Resources =
+                [
+                    new Resource
+                    {
+                        Frequency = "4m",
+                        Resources = new Dictionary<string, ResourceInstance>
+                        {
+                            ["db1"] = new ResourceInstance
+                            {
+                                Id = "db1",
+                                ResourceId = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Sql/servers/srv/databases/mydb",
+                                ResourceFilter = resourceFilter,
+                            },
+                        },
+                    },
+                ],
+            };
+        }
+    }
+}

--- a/autoscalertests/ResourceManagerTests.cs
+++ b/autoscalertests/ResourceManagerTests.cs
@@ -1,0 +1,195 @@
+using Azure.ResourceManager;
+using Microsoft.Extensions.Logging;
+using Moq;
+using poolautoscaler.configuration;
+using poolautoscaler.resourcemanagement;
+using poolautoscaler.resourcemanagement.Dto;
+
+namespace poolautoscaler.tests
+{
+    /// <summary>
+    /// Tests for ResourceManager centralized filtering (tasks 7.2, 7.3, 7.4).
+    /// </summary>
+    public class ResourceManagerTests
+    {
+        private readonly Mock<ILoggerFactory> logFactoryMock;
+        private readonly Mock<ILogger> loggerMock;
+        private readonly Mock<IResourceStateFactory> factoryMock;
+        private readonly Mock<ArmClient> armClientMock;
+
+        public ResourceManagerTests()
+        {
+            this.loggerMock = new Mock<ILogger>();
+            this.logFactoryMock = new Mock<ILoggerFactory>();
+            this.logFactoryMock.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(this.loggerMock.Object);
+            this.factoryMock = new Mock<IResourceStateFactory>();
+            this.armClientMock = new Mock<ArmClient>();
+        }
+
+        [Fact]
+        public async Task DiscoverAsync_WithFilter_OnlyPassingResourcesAreCreated()
+        {
+            var dtuId = "/subs/s/rg/r/srv/databases/db-dtu";
+            var vcoreId = "/subs/s/rg/r/srv/databases/db-vcore";
+            var poolId = "/subs/s/rg/r/srv/databases/db-pool";
+
+            this.factoryMock
+                .Setup(f => f.ExpandResourcesAsync(It.IsAny<ArmClient>(), "db", It.IsAny<string>(), It.IsAny<ILogger>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Dictionary<string, ExpandedResource>
+                {
+                    ["db_db-dtu"] = MakeExpanded(dtuId, "db-dtu"),
+                    ["db_db-vcore"] = MakeExpanded(vcoreId, "db-vcore"),
+                    ["db_db-pool"] = MakeExpanded(poolId, "db-pool"),
+                });
+
+            this.factoryMock
+                .Setup(f => f.Create(dtuId, It.IsAny<ILogger>(), It.IsAny<Resource>(), It.IsAny<ResourceInstance>()))
+                .Returns(MakeState(dtuId));
+
+            var resource = BuildResource("db", "/subs/s/rg/r/srv/databases/*", filter: ctx => ctx.ResourceName == "db-dtu");
+            var manager = new ResourceManager(this.logFactoryMock.Object, this.factoryMock.Object);
+
+            await manager.DiscoverAsync(this.armClientMock.Object, new[] { resource }, TimeSpan.Zero);
+
+            this.factoryMock.Verify(
+                f => f.Create(dtuId, It.IsAny<ILogger>(), It.IsAny<Resource>(), It.IsAny<ResourceInstance>()),
+                Times.Once);
+            this.factoryMock.Verify(
+                f => f.Create(vcoreId, It.IsAny<ILogger>(), It.IsAny<Resource>(), It.IsAny<ResourceInstance>()),
+                Times.Never);
+            this.factoryMock.Verify(
+                f => f.Create(poolId, It.IsAny<ILogger>(), It.IsAny<Resource>(), It.IsAny<ResourceInstance>()),
+                Times.Never);
+            Assert.Single(manager.Resources);
+            Assert.True(manager.Resources.ContainsKey("db_db-dtu"));
+        }
+
+        [Fact]
+        public async Task DiscoverAsync_WithNoFilter_AllExpandedResourcesAreCreated()
+        {
+            var id1 = "/subs/s/rg/r/srv/databases/db1";
+            var id2 = "/subs/s/rg/r/srv/databases/db2";
+
+            this.factoryMock
+                .Setup(f => f.ExpandResourcesAsync(It.IsAny<ArmClient>(), "db", It.IsAny<string>(), It.IsAny<ILogger>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Dictionary<string, ExpandedResource>
+                {
+                    ["db_db1"] = MakeExpanded(id1, "db1"),
+                    ["db_db2"] = MakeExpanded(id2, "db2"),
+                });
+
+            this.factoryMock
+                .Setup(f => f.Create(It.IsAny<string>(), It.IsAny<ILogger>(), It.IsAny<Resource>(), It.IsAny<ResourceInstance>()))
+                .Returns<string, ILogger, Resource, ResourceInstance?>((rid, l, r, ri) => MakeState(rid));
+
+            var resource = BuildResource("db", "/subs/s/rg/r/srv/databases/*", filter: null);
+            var manager = new ResourceManager(this.logFactoryMock.Object, this.factoryMock.Object);
+
+            await manager.DiscoverAsync(this.armClientMock.Object, new[] { resource }, TimeSpan.Zero);
+
+            this.factoryMock.Verify(f => f.Create(id1, It.IsAny<ILogger>(), It.IsAny<Resource>(), It.IsAny<ResourceInstance>()), Times.Once);
+            this.factoryMock.Verify(f => f.Create(id2, It.IsAny<ILogger>(), It.IsAny<Resource>(), It.IsAny<ResourceInstance>()), Times.Once);
+            Assert.Equal(2, manager.Resources.Count);
+        }
+
+        [Fact]
+        public async Task DiscoverAsync_WithFilterButNullContext_ResourceIsAlwaysCreated()
+        {
+            var literalId = "/subs/s/rg/r/srv/databases/mydb";
+
+            this.factoryMock
+                .Setup(f => f.ExpandResourcesAsync(It.IsAny<ArmClient>(), "db", It.IsAny<string>(), It.IsAny<ILogger>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Dictionary<string, ExpandedResource>
+                {
+                    ["db"] = MakeExpanded(literalId, hasContext: false),
+                });
+
+            this.factoryMock
+                .Setup(f => f.Create(literalId, It.IsAny<ILogger>(), It.IsAny<Resource>(), It.IsAny<ResourceInstance>()))
+                .Returns(MakeState(literalId));
+
+            var resource = BuildResource("db", literalId, filter: _ => false);
+            var manager = new ResourceManager(this.logFactoryMock.Object, this.factoryMock.Object);
+
+            await manager.DiscoverAsync(this.armClientMock.Object, new[] { resource }, TimeSpan.Zero);
+
+            this.factoryMock.Verify(
+                f => f.Create(literalId, It.IsAny<ILogger>(), It.IsAny<Resource>(), It.IsAny<ResourceInstance>()),
+                Times.Once);
+            Assert.Single(manager.Resources);
+        }
+
+        [Fact]
+        public async Task DiscoverAsync_WithFilter_CorrectNumberOfResourcesAreCreated()
+        {
+            var allIds = Enumerable.Range(1, 5)
+                .Select(i => (Key: $"db_{i}", Id: $"/subs/s/rg/r/srv/databases/db{i}", Name: $"db_{i}"))
+                .ToList();
+
+            this.factoryMock
+                .Setup(f => f.ExpandResourcesAsync(It.IsAny<ArmClient>(), "db", It.IsAny<string>(), It.IsAny<ILogger>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(allIds.ToDictionary(t => t.Key, t => MakeExpanded(t.Id, t.Name)));
+
+            this.factoryMock
+                .Setup(f => f.Create(It.IsAny<string>(), It.IsAny<ILogger>(), It.IsAny<Resource>(), It.IsAny<ResourceInstance>()))
+                .Returns<string, ILogger, Resource, ResourceInstance?>((rid, l, r, ri) => MakeState(rid));
+
+            var resource = BuildResource(
+                "db",
+                "/subs/s/rg/r/srv/databases/*",
+                filter: ctx => ctx.ResourceName is "db_1" or "db_2" or "db_3");
+
+            var manager = new ResourceManager(this.logFactoryMock.Object, this.factoryMock.Object);
+
+            await manager.DiscoverAsync(this.armClientMock.Object, new[] { resource }, TimeSpan.Zero);
+
+            Assert.Equal(3, manager.Resources.Count);
+            Assert.True(manager.Resources.ContainsKey("db_1"));
+            Assert.True(manager.Resources.ContainsKey("db_2"));
+            Assert.True(manager.Resources.ContainsKey("db_3"));
+            Assert.False(manager.Resources.ContainsKey("db_4"));
+            Assert.False(manager.Resources.ContainsKey("db_5"));
+        }
+
+        private static ResourceState MakeState(string resourceId)
+        {
+            return new TestResourceState(resourceId, new Mock<ILogger>().Object, new Resource());
+        }
+
+        private static ExpandedResource MakeExpanded(string resourceId, string? name = null, bool hasContext = true)
+        {
+            ResourceFilterContext? ctx = hasContext
+                ? new ResourceFilterContext
+                {
+                    ResourceName = name ?? resourceId,
+                    Tags = new Dictionary<string, string>(),
+                    Resource = new object(),
+                }
+                : null;
+
+            return new ExpandedResource { ResourceId = resourceId, Context = ctx };
+        }
+
+        private static Resource BuildResource(
+            string instanceKey,
+            string resourceId,
+            Func<ResourceFilterContext, bool>? filter = null)
+        {
+            return new Resource
+            {
+                Enabled = true,
+                Frequency = "4m",
+                FrequencyParsed = TimeSpan.FromMinutes(4),
+                Resources = new Dictionary<string, ResourceInstance>
+                {
+                    [instanceKey] = new ResourceInstance
+                    {
+                        Id = instanceKey,
+                        ResourceId = resourceId,
+                        ResourceFilterExpression = filter,
+                    },
+                },
+            };
+        }
+    }
+}

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.419",
+    "rollForward": "latestPatch"
+  }
+}

--- a/openspec/changes/archive/2026-05-04-resource-instance-filter/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-04-resource-instance-filter/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-04

--- a/openspec/changes/archive/2026-05-04-resource-instance-filter/design.md
+++ b/openspec/changes/archive/2026-05-04-resource-instance-filter/design.md
@@ -1,0 +1,78 @@
+## Context
+
+Resource discovery uses wildcard expansion to enumerate all matching Azure resources (e.g. `databases/*` lists every database under a server). All expanded resources enter the processing loop regardless of their properties. Metrics and dimensions are model-specific, so a DTU-targeted config block applied to a vCore or elastic pool database produces 400 errors from Azure Monitor, triggering a 1-hour resource lockout.
+
+The codebase already has `ExpressionParserUtils` (Dynamic LINQ) for compiling C# lambda strings at startup, `IsDtuModel` in `MsSqlDatabaseResourceStateHelper`, and `CanApplyDimension` filtering at rule-execution time. What is missing is an operator-visible, config-level mechanism to exclude resources before they enter the loop.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Allow operators to write a predicate lambda in `ResourceInstance.ResourceFilter` that is evaluated once per expanded resource during discovery.
+- Resources returning `false` are excluded from the discovered set and never processed.
+- Compile the predicate at startup (fail-fast on bad expressions).
+- Provide a `ResourceFilterContext` with pre-computed, human-friendly properties so operators don't need to know internal ARM types or cast.
+- Apply filtering inside each wildcard expansion helper (data already fetched there, no extra API calls).
+
+**Non-Goals:**
+- Runtime re-evaluation of the filter after discovery (filter is expansion-time only).
+- Lambda access to metric data or scaling state (use ScaleUpCondition for that).
+- Filtering non-wildcard (literal) resource IDs — the filter is silently ignored for non-expanded resources.
+- Changing any behavior for configs that omit `ResourceFilter`.
+
+## Decisions
+
+### Decision 1: Expansion helpers return context; filtering is centralized in ResourceManager
+
+**Chosen**: `ExpandResourcesAsync` (and each expansion helper) returns `Dictionary<string, ExpandedResource>` instead of `Dictionary<string, string>`. `ExpandedResource` carries both the `ResourceId` string and a `ResourceFilterContext` built from the ARM data already fetched during expansion. `ResourceManager.DiscoverCoreAsync` evaluates the compiled filter against the context after expansion, before calling `Create()`, and logs each exclusion at `Information` level.
+
+**Alternative considered**: Pass the compiled filter *into* each expansion helper and apply it inside the `foreach` loop. This works but scatters filter evaluation across every helper, prevents centralized logging (the helper can't easily report "X of Y excluded"), and requires threading the filter through `IResourceStateFactory.ExpandResourcesAsync` and every call site.
+
+**Rationale**: Expansion helpers already fetch the ARM resource data in their loop — returning a `ResourceFilterContext` alongside the ID costs nothing extra. Centralizing the filter decision in `ResourceManager` enables a single, accurate log line ("N discovered, M filtered out, K added"), keeps expansion helpers filter-unaware, and avoids changing `IResourceStateFactory`'s parameter surface. For non-wildcard (literal) resource IDs, the expansion helper sets `Context = null`; `ResourceManager` skips the filter evaluation and always includes the resource.
+
+### Decision 2: `ResourceFilterContext` as the lambda parameter type — generic with a `Properties` bag
+
+**Chosen**: Compile the filter as `Func<ResourceFilterContext, bool>`. `ResourceFilterContext` contains:
+- `ResourceName` (`string`) — always populated
+- `Tags` (`IDictionary<string, string>`) — Azure resource tags (available on all ARM resources)
+- `Resource` (`object`) — the raw ARM resource; Dynamic LINQ resolves members against the actual runtime type
+
+Operators access resource-specific data directly via `r.Resource` (e.g. `r.Resource.Data.Sku.Family == null`), which is identical to the existing `DataExpression` pattern where `data.Resource.Data.Sku.Name` is already used in production configs. No `Properties` bag is needed.
+
+**Alternative A**: Bake resource-type-specific flags (`IsDtuModel`, `IsElasticPool`) as first-class properties on the context class, or a `Properties` dictionary — either adds pre-computation work to every expansion helper and duplicates data already accessible on the ARM object.
+
+**Alternative B**: `Func<ArmResource, bool>` using the base class directly — would require ARM SDK casts for concrete type members.
+
+**Alternative C**: `Func<dynamic, bool>` — no compile-time validation; errors surface at runtime.
+
+**Rationale**: `CustomMetricDataContext.Resource` is already `object`-typed and operators already write `data.Resource.Data.Sku.Name` in real configs. Dynamic LINQ resolves the members against the runtime type. Reusing this exact pattern keeps the context class minimal and eliminates all pre-computation from expansion helpers — they simply set `Resource = <arm object>`.
+
+### Decision 3: Compile at startup in `Configuration.PrepareAndValidate`
+
+**Chosen**: Compile `ResourceFilter` to `ResourceFilterExpression` during `PrepareAndValidate`, same as all other lambda expressions.
+
+**Rationale**: Fail-fast on bad expressions before any Azure calls are made. Consistent with existing pattern for `ScaleUpCondition`, `ScaleDownCondition`, `DataExpression`.
+
+### Decision 4: `ResourceFilterContext` placed in `configuration/` namespace
+
+**Chosen**: `poolautoscaler.configuration.ResourceFilterContext`.
+
+**Rationale**: It is a configuration-layer concept (the contract between YAML and the filter lambda). Keeping it adjacent to `ResourceInstance` and `Metric` makes the ownership clear. It does not depend on `resourcemanagement` internals.
+
+### Decision 5: `ExpandResourcesAsync` return type changes to carry context
+
+**Chosen**: `IResourceStateFactory.ExpandResourcesAsync` returns `Dictionary<string, ExpandedResource>` (a new thin type: `ResourceId` string + `ResourceFilterContext?`). All existing callers that only needed the ID string are updated. Expansion helpers build and return a `ResourceFilterContext` for each wildcard-expanded resource; for non-wildcard (literal) resources the context is `null`.
+
+**Alternative**: Keep the return type as `Dictionary<string, string>` and add a parallel context dictionary. This avoids touching the return type but makes the API awkward and forces callers to correlate two dictionaries by key.
+
+**Rationale**: The return type change is contained to an internal interface. It makes the contract explicit: expansion now produces both an ID and the data needed for filtering. `ResourceManager` is the only consumer of `ExpandResourcesAsync` so the blast radius of the type change is small.
+
+## Risks / Trade-offs
+
+- **Risk**: Operators write filters that exclude all resources silently → nothing gets scaled. Mitigation: log `LogInformation` for each resource excluded by the filter during expansion, including the resource name and the filter expression source.
+- **Risk**: `ResourceFilterContext` properties populated from ARM types change with SDK upgrades. Mitigation: map only stable, documented properties (`Sku.Name`, `Sku.Family`, `ElasticPoolId`).
+- **Risk**: Filter expression references types not known to Dynamic LINQ. Mitigation: `ResourceFilterContext` is added to `MyCustomTypeProvider`; simple boolean/string properties don't require additional type registrations.
+- **Trade-off**: Expansion helpers for resource types that don't support wildcards (Fabric Capacity, Azure DevOps) receive the filter but it has no effect. Acceptable — non-wildcard resources produce a single-entry dictionary and the filter has no ARM object to evaluate against. Document this in the property summary.
+
+## Migration Plan
+
+No migration required. `ResourceFilter` is optional; existing configs without it compile and run identically. The new optional parameter on `ExpandResourcesAsync` defaults to `null`, preserving all existing call sites.

--- a/openspec/changes/archive/2026-05-04-resource-instance-filter/proposal.md
+++ b/openspec/changes/archive/2026-05-04-resource-instance-filter/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+When a wildcard ResourceId (e.g. `databases/*`) expands to multiple databases, resources of different SKU models (DTU standalone, elastic pool, vCore) all enter the same processing loop. Metrics and dimensions are model-specific — fetching `dtu_consumption_percent` against a vCore database returns a 400 error and disables the resource for one hour. There is no config-level mechanism to include or exclude resources by their runtime properties; operators must either list databases explicitly or rely on silent internal filtering that isn't visible in the YAML.
+
+## What Changes
+
+- A new optional `ResourceFilter` string property on `ResourceInstance` accepts a C# lambda expression evaluated at resource discovery time.
+- A new lean `ResourceFilterContext` class exposes `ResourceName` (string), `Tags` (Azure resource tags), and `Resource` (the raw ARM object). Operators access resource-type-specific properties directly via `r.Resource` — the same pattern already used in `DataExpression` lambdas (`data.Resource.Data.Sku.Name`).
+- The filter is compiled via the existing `ExpressionParserUtils` infrastructure and applied inside each wildcard expansion helper, so resources that do not match are never added to the processing loop.
+- `MyCustomTypeProvider` is updated to expose `ResourceFilterContext` to Dynamic LINQ.
+- `IResourceStateFactory.ExpandResourcesAsync` and all expansion helpers are updated to accept and apply the compiled filter.
+
+## Capabilities
+
+### New Capabilities
+
+- `resource-instance-filter`: Allows operators to write a lambda expression in `ResourceInstance.ResourceFilter` that is evaluated for each expanded resource during discovery. Resources returning `false` are excluded from the processing loop entirely.
+
+### Modified Capabilities
+
+_(none — no existing spec-level behavior changes)_
+
+## Impact
+
+- **Configuration**: `ResourceInstance` gains a new optional `ResourceFilter` field.
+- **Code**: `ResourceInstance.cs`, `Configuration.cs`, `IResourceStateFactory.cs`, `ResourceStateFactory.cs`, `ResourceManager.cs`, `MsSqlDatabaseResourceStateHelper.cs`, `MssqlElasticPoolResourceStateHelper.cs`, `AksNodePoolResourceStateHelper.cs` (and other expand helpers), `MyCustomTypeProvider.cs`.
+- **New file**: `ResourceFilterContext.cs` (in `configuration/` or `resourcemanagement/Dto/`).
+- **No breaking changes** — `ResourceFilter` is optional; existing configs without it behave identically.

--- a/openspec/changes/archive/2026-05-04-resource-instance-filter/specs/resource-instance-filter/spec.md
+++ b/openspec/changes/archive/2026-05-04-resource-instance-filter/specs/resource-instance-filter/spec.md
@@ -1,0 +1,68 @@
+## ADDED Requirements
+
+### Requirement: ResourceInstance accepts a ResourceFilter lambda expression
+`ResourceInstance` SHALL expose an optional `ResourceFilter` string property containing a C# lambda expression. When set, the system SHALL compile it at startup as `Func<ResourceFilterContext, bool>` and store it in `ResourceFilterExpression`. If the expression fails to compile, startup SHALL fail with a descriptive error.
+
+#### Scenario: Valid filter compiles at startup
+- **WHEN** `ResourceFilter` is set to a syntactically valid lambda (e.g. `"(r) => r.Resource.Data.Sku.Family == null"`)
+- **THEN** `ResourceFilterExpression` is non-null and startup succeeds
+
+#### Scenario: Invalid filter fails at startup
+- **WHEN** `ResourceFilter` contains a lambda that does not compile (e.g. `"(r) => r.Nonexistent"`)
+- **THEN** startup throws an exception with a message indicating the invalid expression
+
+#### Scenario: Absent filter is ignored
+- **WHEN** `ResourceFilter` is null or not set in the configuration
+- **THEN** `ResourceFilterExpression` is null and all expanded resources are included as before
+
+---
+
+### Requirement: ResourceFilterContext exposes resource properties for filtering
+The system SHALL provide a `ResourceFilterContext` class as the lambda parameter. It SHALL expose:
+- `ResourceName` (`string`) — the name of the resource (database name, pool name, share name, etc.), always populated
+- `Tags` (`IDictionary<string, string>`) — the Azure resource tags at expansion time, always populated (empty dict if none)
+- `Resource` (`object`) — the raw ARM resource object (e.g. `SqlDatabaseResource`); Dynamic LINQ resolves members against the actual runtime type, consistent with the existing `CustomMetricDataContext.Resource` pattern
+
+Operators access resource-type-specific properties directly via `r.Resource` (e.g. `r.Resource.Data.Sku.Family`), the same way `DataExpression` already uses `data.Resource.Data.Sku.Name`.
+
+#### Scenario: SQL DTU standalone database accessible via Resource
+- **WHEN** a wildcard expands to a SQL database with SKU Name `"Standard"` and no Family
+- **THEN** `r.Resource.Data.Sku.Name` evaluates to `"Standard"` and `r.Resource.Data.Sku.Family` evaluates to `null` in the filter expression
+
+#### Scenario: Filter expression accesses ARM properties at runtime
+- **WHEN** `ResourceFilter` is `"(r) => r.Resource.Data.Sku.Family == null && r.Resource.Data.Sku.Name != \"ElasticPool\""`
+- **THEN** the expression correctly identifies standalone DTU databases and excludes elastic pool and vCore databases
+
+#### Scenario: Tags are accessible for tag-based filtering
+- **WHEN** `ResourceFilter` is `"(r) => r.Tags.ContainsKey(\"env\") && r.Tags[\"env\"] == \"prod\""`
+- **THEN** only resources tagged `env=prod` are included in the discovered set
+
+---
+
+### Requirement: Resources failing the filter are excluded from discovery with summary logging
+When `ResourceFilterExpression` is set, the system SHALL evaluate it inside `ResourceManager.DiscoverCoreAsync` after expansion but before creating the resource state, using the `ResourceFilterContext` returned alongside each resource ID. Resources for which the expression returns `false` SHALL NOT be added to the discovered resource set. After processing each `ResourceInstance`, the system SHALL emit a single `Information`-level summary log reporting the counts of discovered, filtered-out, and added/kept resources.
+
+#### Scenario: DTU-only filter excludes vCore databases
+- **WHEN** `ResourceFilter` is `"(r) => r.Resource.Data.Sku.Family == null && r.Resource.Data.Sku.Name != \"ElasticPool\""` and the wildcard expands to a mix of DTU and vCore databases
+- **THEN** only DTU databases are added to the resource set; vCore databases are excluded
+
+#### Scenario: Summary log is emitted per ResourceInstance
+- **WHEN** a wildcard expands to 5 databases and 3 pass the filter
+- **THEN** an `Information`-level log is emitted stating 5 were discovered, 2 were filtered out, and 3 were added or kept
+
+#### Scenario: Included resources behave identically to unfiltered resources
+- **WHEN** a resource passes the filter (returns `true`)
+- **THEN** it is added to the discovered set and processed exactly as it would be without a filter
+
+#### Scenario: Filter with no wildcard has no effect
+- **WHEN** `ResourceFilter` is set on a `ResourceInstance` whose `ResourceId` does not contain a wildcard pattern
+- **THEN** the single resource is included regardless of the filter expression (`Context` is null for literal IDs; the filter is skipped)
+
+---
+
+### Requirement: ResourceFilterContext is available to Dynamic LINQ expressions
+The system SHALL register `ResourceFilterContext` in `MyCustomTypeProvider` so that Dynamic LINQ can resolve it without requiring fully-qualified type names in the lambda string.
+
+#### Scenario: Filter lambda references ResourceFilterContext properties without qualification
+- **WHEN** `ResourceFilter` is `"(r) => r.Resource.Data.Sku.Family == null"` (no namespace prefix on `ResourceFilterContext`)
+- **THEN** the expression compiles successfully

--- a/openspec/changes/archive/2026-05-04-resource-instance-filter/tasks.md
+++ b/openspec/changes/archive/2026-05-04-resource-instance-filter/tasks.md
@@ -1,0 +1,43 @@
+## 1. New Types
+
+- [x] 1.1 Create `configuration/ResourceFilterContext.cs` with `ResourceName` (string), `Tags` (IDictionary&lt;string,string&gt;), and `Resource` (object — Dynamic LINQ resolves members against the actual runtime type, same as `CustomMetricDataContext.Resource`)
+- [x] 1.2 Create `resourcemanagement/Dto/ExpandedResource.cs` with `ResourceId` (string) and `Context` (ResourceFilterContext?, null for non-wildcard resources)
+- [x] 1.3 Add `ResourceFilterContext` to `MyCustomTypeProvider.GetCustomTypes()`
+
+## 2. Configuration Layer
+
+- [x] 2.1 Add `ResourceFilter` (string) and `ResourceFilterExpression` (`Func<ResourceFilterContext, bool>?`) properties to `ResourceInstance`
+- [x] 2.2 In `Configuration.PrepareAndValidate`, iterate `resource.Resources` and compile `ResourceFilter` via `ExpressionParserUtils.ParseExpression` into `ResourceFilterExpression` (fail-fast on parse error)
+
+## 3. Expansion Interface & Return Type
+
+- [x] 3.1 Change `IResourceStateFactory.ExpandResourcesAsync` return type from `Dictionary<string, string>` to `Dictionary<string, ExpandedResource>`
+- [x] 3.2 Update `ResourceStateFactory.ExpandResourcesAsync` to match the new return type and thread `ExpandedResource` results from each expansion helper
+
+## 4. SQL Database Expansion
+
+- [x] 4.1 Change `MsSqlDatabaseResourceStateHelper.ExpandSqlDatabaseWildcard` return type to `Dictionary<string, ExpandedResource>`
+- [x] 4.2 Inside the database `foreach`, build `ResourceFilterContext { ResourceName = database.Data.Name, Tags = database.Data.Tags, Resource = database }` and return it in `ExpandedResource` alongside the expanded resource ID
+
+## 5. Other Expansion Helpers
+
+- [x] 5.1 Change `MssqlElasticPoolResourceStateHelper.ExpandElasticPoolWildcard` to return `Dictionary<string, ExpandedResource>`, populating `ResourceFilterContext { ResourceName, Tags, Resource = elasticPool }`
+- [x] 5.2 Change `AksNodePoolResourceStateHelper.ExpandNodePoolWildcard` to return `Dictionary<string, ExpandedResource>`, populating `ResourceFilterContext { ResourceName, Tags, Resource = agentPool }`
+- [x] 5.3 Change `StorageFileShareResourceStateHelper.ExpandFileShareWildcard` to return `Dictionary<string, ExpandedResource>`, populating `ResourceFilterContext { ResourceName, Tags, Resource = share }`
+
+## 6. ResourceManager — Centralized Filtering
+
+- [x] 6.1 Update `ResourceManager.DiscoverCoreAsync` to iterate `Dictionary<string, ExpandedResource>` instead of `Dictionary<string, string>`
+- [x] 6.2 After expanding each `ResourceInstance`, evaluate `resourceInstance.Value.ResourceFilterExpression` against each `ExpandedResource.Context` (skip evaluation when `Context` is null — non-wildcard resources always pass)
+- [x] 6.3 Track `discoveredCount`, `filteredCount`, `addedCount` per `ResourceInstance` and emit a single `LogInformation` summary after processing all expanded resources for that instance
+
+## 7. Tests
+
+- [x] 7.1 In `Configuration.PrepareAndValidate` tests (new or existing): assert a valid `ResourceFilter` compiles without error; assert an invalid expression throws at startup with a descriptive message
+- [x] 7.2 Create `ResourceManagerTests.cs`: mock `IResourceStateFactory.ExpandResourcesAsync` to return a mix of `ExpandedResource` entries with different contexts; assert only resources passing the filter are passed to `Create()`; assert the summary log counts (discovered / filtered / added) are correct
+- [x] 7.3 In `ResourceManagerTests.cs`: assert that when `ResourceFilter` is null, all expanded resources are created (no regression)
+- [x] 7.4 In `ResourceManagerTests.cs`: assert that when `Context` is null (non-wildcard resource), the filter is skipped and the resource is always created
+
+## 8. Documentation
+
+- [x] 8.1 Update `config.yml.example` to add a commented `ResourceFilter` example under the SQL database resource block showing the DTU filter pattern

--- a/openspec/changes/archive/2026-05-04-scale-completion-log-duration/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-04-scale-completion-log-duration/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-23

--- a/openspec/changes/archive/2026-05-04-scale-completion-log-duration/design.md
+++ b/openspec/changes/archive/2026-05-04-scale-completion-log-duration/design.md
@@ -1,0 +1,40 @@
+## Context
+
+- Background scale applies run inside `Task.Run` in `ResourceProcessor` after a patch is prepared; `resState.Logger` produces resource-scoped log prefixes (e.g. pool name and index).
+- Successful completion is currently logged with a fixed message after `ApplyChanges` returns and `LastScale` is updated (`openspec/knowledge/staging/internal/scale-operation-background-logging.md`).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Include elapsed wall-clock time for the apply in the success log line, formatted as `HH:mm:ss` where the first field is **total whole hours** of the span (so multi-day runs do not silently wrap).
+- Keep log level and general semantics (successful completion) unchanged.
+
+**Non-Goals:**
+
+- Duration on cancelled or failed paths (only the success line in scope unless product later asks).
+- Sub-second precision (format is second granularity).
+- New metrics, App Insights events, or dashboards.
+
+## Decisions
+
+1. **Time source** — Record `startUtc = getUtcNow()` immediately before `await resState.ApplyChanges(...)` (or immediately after the “Starting scale operation” line). Compute `elapsed = getUtcNow() - startUtc` after `ApplyChanges` completes. Reuses the same `getUtcNow` delegate already injected on the processor (consistent with `LastScale`).
+
+2. **Format** — Build a display string `HH:mm:ss` using total hours and the `TimeSpan` minute/second components: `(int)elapsed.TotalHours`, `elapsed.Minutes`, `elapsed.Seconds`, each zero-padded to two digits. **Do not** use `TimeSpan.ToString(@"hh\:mm\:ss")` alone; for spans ≥ 24h the `hh` segment resets and misrepresents duration.
+
+3. **Logging API** — Use `LogInformation` with a message template and a dedicated placeholder, e.g. `"Scale operation completed successfully after {Elapsed}"` where `Elapsed` is the formatted string (structured field remains queryable). Adjust wording minimally so existing “Scale operation completed successfully” intent is obvious.
+
+4. **Tests** — If there are unit/integration tests that assert the exact log message, update expected text or switch assertions to structured property checks where appropriate.
+
+## Risks / Trade-offs
+
+- **[Risk] Fragile log substring alerts** — Mitigation: document the new template; prefer structured `Elapsed` for monitors.
+- **[Risk] Very long runs** — Mitigation: `TotalHours` as int can exceed 99; format still valid (e.g. `100:05:03`). If product wants a cap, that would be a follow-up.
+
+## Migration Plan
+
+- Deploy with code change only; no data migration. Rollback is revert commit.
+
+## Open Questions
+
+- None for MVP; confirm with stakeholders if cancel/failure logs should also include partial duration.

--- a/openspec/changes/archive/2026-05-04-scale-completion-log-duration/proposal.md
+++ b/openspec/changes/archive/2026-05-04-scale-completion-log-duration/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Operators rely on completion logs to correlate scale runs with incidents and Azure activity. Today the success line does not say how long the operation took, so triage requires guessing or cross-referencing other telemetry. Adding an explicit elapsed duration makes each scale cycle self-describing in log streams.
+
+## What Changes
+
+- Extend the informational log emitted when a background scale operation finishes successfully so it includes elapsed time formatted as `HH:mm:ss` (total hours, not clock time).
+- Use a duration-safe format so spans longer than 24 hours still render correctly (total hours in the first segment).
+
+## Capabilities
+
+### New Capabilities
+
+- `scale-operation-completion-log`: Requirements for the text and structured fields of scale completion (and related) log lines when a background apply finishes.
+
+### Modified Capabilities
+
+<!-- No existing specs in openspec/specs/. -->
+
+## Impact
+
+- **Code**: `autoscaler/resourcemanagement/ResourceProcessor.cs` — background `Task.Run` that calls `ApplyChanges` and logs `Scale operation completed successfully`.
+- **Logging**: Same category/level; message template gains a duration placeholder. Downstream log queries that match the exact old string may need updating if they are brittle.
+- **Knowledge**: Internal research staged at `openspec/knowledge/staging/internal/scale-operation-background-logging.md` (flow, file location, duration formatting note).

--- a/openspec/changes/archive/2026-05-04-scale-completion-log-duration/specs/scale-operation-completion-log/spec.md
+++ b/openspec/changes/archive/2026-05-04-scale-completion-log-duration/specs/scale-operation-completion-log/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: Successful scale completion log includes elapsed duration
+
+When a background scale operation completes successfully, the autoscaler SHALL emit an informational log that states the operation completed successfully and includes the elapsed time from the start of that apply until completion, formatted as `HH:mm:ss`, where the first segment is the total whole number of hours in the elapsed span (not a 24-hour clock).
+
+#### Scenario: Apply finishes after measurable elapsed time
+
+- **WHEN** a background scale apply starts and later completes without error
+- **THEN** the success log line MUST include a duration string matching the pattern `H+:MM:SS` (one or more hour digits, two-digit minutes, two-digit seconds) derived from UTC elapsed time between apply start and apply completion
+
+#### Scenario: Apply spans more than twenty-four hours
+
+- **WHEN** the elapsed time between apply start and completion is 25 hours or more
+- **THEN** the hour segment of the duration string MUST reflect total hours (e.g. `25:00:00` for twenty-five hours), not a value that wraps within 0–23

--- a/openspec/changes/archive/2026-05-04-scale-completion-log-duration/tasks.md
+++ b/openspec/changes/archive/2026-05-04-scale-completion-log-duration/tasks.md
@@ -1,0 +1,19 @@
+## Documentation / reading order (implementation)
+
+Read before coding:
+
+1. `openspec/changes/scale-completion-log-duration/proposal.md` — intent and scope
+2. `openspec/changes/scale-completion-log-duration/design.md` — time capture, duration format, logging shape
+3. `openspec/changes/scale-completion-log-duration/specs/scale-operation-completion-log/spec.md` — acceptance criteria
+4. `openspec/knowledge/staging/internal/scale-operation-background-logging.md` — code location and flow notes
+
+## 1. Implementation
+
+- [x] 1.1 In `autoscaler/resourcemanagement/ResourceProcessor.cs`, capture UTC start time before `await resState.ApplyChanges` in the background scale task (same `getUtcNow` as existing `LastScale` usage).
+- [x] 1.2 After `ApplyChanges` completes successfully, compute elapsed `TimeSpan` and format duration as `HH:mm:ss` using total whole hours plus minute and second components (see design — avoid `hh` TimeSpan format alone).
+- [x] 1.3 Update the success `LogInformation` call to include the formatted duration with a structured template property (e.g. `{Elapsed}`).
+
+## 2. Verification
+
+- [x] 2.1 Run/build tests; update or add assertions if any test fixes the exact completion log string.
+- [x] 2.2 Manually confirm a sample log line reads like success text plus `after 00:01:23` (or similar) for a short run.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours

--- a/openspec/knowledge.staging.md
+++ b/openspec/knowledge.staging.md
@@ -1,0 +1,20 @@
+# Knowledge staging
+
+Items below are unchecked until processed by `knowledge-archive`.
+
+## Sources
+
+- [ ] **C# DTO optional diagnostics & deferred logging (.NET 8)**
+  - scope: internal
+  - type: research
+  - description: Patterns for attaching optional diagnostic/structured data to DTOs, single log at significant events, ILogger message templates vs multi-line strings, avoiding duplicate logs, separating raw evaluation data from table formatting.
+  - local: knowledge/staging/internal/dotnet-dto-deferred-diagnostic-logging.md
+  - urls: https://learn.microsoft.com/en-us/dotnet/core/extensions/logging, https://learn.microsoft.com/en-us/dotnet/core/extensions/high-performance-logging
+  - from-topic: Research for C# .NET 8 — optional diagnostic text/structured data on DTOs for deferred logging on scale operations; string vs lines vs object; structured logging; deduplication; data vs presentation.
+
+- [ ] **Background scale operation logging (ResourceProcessor)**
+  - scope: internal
+  - type: codebase
+  - description: Where scale completion is logged, background Task.Run flow, scoped logger; duration formatting note for HH:mm:ss across multi-day spans.
+  - local: knowledge/staging/internal/scale-operation-background-logging.md
+  - from-topic: Include elapsed time (HH:mm:ss) on "Scale operation completed successfully" log line.

--- a/openspec/knowledge/staging/internal/dotnet-dto-deferred-diagnostic-logging.md
+++ b/openspec/knowledge/staging/internal/dotnet-dto-deferred-diagnostic-logging.md
@@ -1,0 +1,27 @@
+# C# / .NET 8 — optional diagnostics on DTOs for deferred logging
+
+## Shape of attached data
+
+- **Prefer structured records** (immutable DTOs, `IReadOnlyList<T>` of row/value types) for anything you might query, test, or re-log; keep primitive scalars and small POCOs — not pre-rendered prose.
+- **`IReadOnlyList<string>`** only when lines are truly unstructured narrative; still risk presentation leaking into the domain.
+- **Single optional `string`** is appropriate for one short human note; avoid stuffing tables or multi-section dumps into it.
+
+## ILogger / multi-line
+
+- Use **message templates with named placeholders** (`LogInformation("Scale {Action} for {ResourceId}", ...)`) so sinks (Application Insights, Serilog, OpenTelemetry) get **separate properties**; avoid `$"..."` for structured fields ([Logging in .NET](https://learn.microsoft.com/en-us/dotnet/core/extensions/logging)).
+- **Multi-line in one message** is usually worse for indexing; either log **one event** with **structured properties** (JSON-serializable fragments, counts, key metrics) or attach a **single diagnostic blob property** your sink renders — not repeated `Environment.NewLine` tables in the template text.
+- For hot paths, **`LoggerMessage` source generators** reduce allocation ([high-performance logging](https://learn.microsoft.com/en-us/dotnet/core/extensions/high-performance-logging)).
+
+## Duplicate logging
+
+- **Accumulate diagnostics on the in-memory DTO/state** during evaluation; emit **one log call** at the boundary (e.g. scale commit) that includes correlation IDs and the deferred payload — intermediate steps should not log the same facts unless levels differ (`Trace` vs `Information`).
+- Optionally use **`ILogger.BeginScope`** with a small dictionary for correlation + deferred keys so one outer log carries context without repeating parameters.
+
+## Data vs presentation
+
+- Store **raw grids** as `IReadOnlyList<MetricEvaluationRow>` (or similar) with numeric/bool/enum fields; **format tables at log time** (or in a custom `ITextFormatter` / enricher) so DTOs stay presentation-free and tests assert on data, not string shape.
+
+## References (external)
+
+- https://learn.microsoft.com/en-us/dotnet/core/extensions/logging
+- https://learn.microsoft.com/en-us/dotnet/core/extensions/high-performance-logging

--- a/openspec/knowledge/staging/internal/scale-operation-background-logging.md
+++ b/openspec/knowledge/staging/internal/scale-operation-background-logging.md
@@ -1,0 +1,21 @@
+# Scale operation (background) logging
+
+## Overview
+
+- Scale applies run in a **fire-and-forget** `Task.Run` after patch preparation; informational logs use `resState.Logger` (scoped resource logger — explains prefix like `sqlsrvdatosetg_pools_sqlpool-default[0]` in output).
+
+## Flow
+
+1. `logger.LogInformation("Dispatching scale operation (background)")` (sync path).
+2. Background task: `Starting scale operation (background)` → `await resState.ApplyChanges(patchOp, stoppingToken)` → `LastScale = getUtcNow()` → `Scale operation completed successfully` (or cancel/error branches).
+
+## Key file
+
+- `autoscaler/resourcemanagement/ResourceProcessor.cs` — background block ~lines 487–512.
+
+## Implementation note (duration HH:mm:ss)
+
+- Capture `var start = getUtcNow()` immediately before/after the start log (or before `ApplyChanges`).
+- After `ApplyChanges`, compute `var elapsed = getUtcNow() - start`.
+- For elapsed **duration** in `HH:mm:ss` where operations may exceed 24h, prefer total hours: `(int)elapsed.TotalHours`, `elapsed.Minutes`, `elapsedSeconds` — **not** `elapsed.Hours` alone (that is the 0–23 component within days).
+- Use structured logging: e.g. template `"Scale operation completed successfully after {Duration}"` with formatted string, or pass `elapsed` and format in template per project conventions.

--- a/openspec/specs/resource-instance-filter/spec.md
+++ b/openspec/specs/resource-instance-filter/spec.md
@@ -1,0 +1,68 @@
+# Resource instance filter
+
+### Requirement: ResourceInstance accepts a ResourceFilter lambda expression
+`ResourceInstance` SHALL expose an optional `ResourceFilter` string property containing a C# lambda expression. When set, the system SHALL compile it at startup as `Func<ResourceFilterContext, bool>` and store it in `ResourceFilterExpression`. If the expression fails to compile, startup SHALL fail with a descriptive error.
+
+#### Scenario: Valid filter compiles at startup
+- **WHEN** `ResourceFilter` is set to a syntactically valid lambda (e.g. `"(r) => r.Resource.Data.Sku.Family == null"`)
+- **THEN** `ResourceFilterExpression` is non-null and startup succeeds
+
+#### Scenario: Invalid filter fails at startup
+- **WHEN** `ResourceFilter` contains a lambda that does not compile (e.g. `"(r) => r.Nonexistent"`)
+- **THEN** startup throws an exception with a message indicating the invalid expression
+
+#### Scenario: Absent filter is ignored
+- **WHEN** `ResourceFilter` is null or not set in the configuration
+- **THEN** `ResourceFilterExpression` is null and all expanded resources are included as before
+
+---
+
+### Requirement: ResourceFilterContext exposes resource properties for filtering
+The system SHALL provide a `ResourceFilterContext` class as the lambda parameter. It SHALL expose:
+- `ResourceName` (`string`) — the name of the resource (database name, pool name, share name, etc.), always populated
+- `Tags` (`IDictionary<string, string>`) — the Azure resource tags at expansion time, always populated (empty dict if none)
+- `Resource` (`object`) — the raw ARM resource object (e.g. `SqlDatabaseResource`); Dynamic LINQ resolves members against the actual runtime type, consistent with the existing `CustomMetricDataContext.Resource` pattern
+
+Operators access resource-type-specific properties directly via `r.Resource` (e.g. `r.Resource.Data.Sku.Family`), the same way `DataExpression` already uses `data.Resource.Data.Sku.Name`.
+
+#### Scenario: SQL DTU standalone database accessible via Resource
+- **WHEN** a wildcard expands to a SQL database with SKU Name `"Standard"` and no Family
+- **THEN** `r.Resource.Data.Sku.Name` evaluates to `"Standard"` and `r.Resource.Data.Sku.Family` evaluates to `null` in the filter expression
+
+#### Scenario: Filter expression accesses ARM properties at runtime
+- **WHEN** `ResourceFilter` is `"(r) => r.Resource.Data.Sku.Family == null && r.Resource.Data.Sku.Name != \"ElasticPool\""`
+- **THEN** the expression correctly identifies standalone DTU databases and excludes elastic pool and vCore databases
+
+#### Scenario: Tags are accessible for tag-based filtering
+- **WHEN** `ResourceFilter` is `"(r) => r.Tags.ContainsKey(\"env\") && r.Tags[\"env\"] == \"prod\""`
+- **THEN** only resources tagged `env=prod` are included in the discovered set
+
+---
+
+### Requirement: Resources failing the filter are excluded from discovery with summary logging
+When `ResourceFilterExpression` is set, the system SHALL evaluate it inside `ResourceManager.DiscoverCoreAsync` after expansion but before creating the resource state, using the `ResourceFilterContext` returned alongside each resource ID. Resources for which the expression returns `false` SHALL NOT be added to the discovered resource set. After processing each `ResourceInstance`, the system SHALL emit a single `Information`-level summary log reporting the counts of discovered, filtered-out, and added/kept resources.
+
+#### Scenario: DTU-only filter excludes vCore databases
+- **WHEN** `ResourceFilter` is `"(r) => r.Resource.Data.Sku.Family == null && r.Resource.Data.Sku.Name != \"ElasticPool\""` and the wildcard expands to a mix of DTU and vCore databases
+- **THEN** only DTU databases are added to the resource set; vCore databases are excluded
+
+#### Scenario: Summary log is emitted per ResourceInstance
+- **WHEN** a wildcard expands to 5 databases and 3 pass the filter
+- **THEN** an `Information`-level log is emitted stating 5 were discovered, 2 were filtered out, and 3 were added or kept
+
+#### Scenario: Included resources behave identically to unfiltered resources
+- **WHEN** a resource passes the filter (returns `true`)
+- **THEN** it is added to the discovered set and processed exactly as it would be without a filter
+
+#### Scenario: Filter with no wildcard has no effect
+- **WHEN** `ResourceFilter` is set on a `ResourceInstance` whose `ResourceId` does not contain a wildcard pattern
+- **THEN** the single resource is included regardless of the filter expression (`Context` is null for literal IDs; the filter is skipped)
+
+---
+
+### Requirement: ResourceFilterContext is available to Dynamic LINQ expressions
+The system SHALL register `ResourceFilterContext` in `MyCustomTypeProvider` so that Dynamic LINQ can resolve it without requiring fully-qualified type names in the lambda string.
+
+#### Scenario: Filter lambda references ResourceFilterContext properties without qualification
+- **WHEN** `ResourceFilter` is `"(r) => r.Resource.Data.Sku.Family == null"` (no namespace prefix on `ResourceFilterContext`)
+- **THEN** the expression compiles successfully

--- a/openspec/specs/scale-operation-completion-log/spec.md
+++ b/openspec/specs/scale-operation-completion-log/spec.md
@@ -1,0 +1,15 @@
+# Scale operation completion log
+
+### Requirement: Successful scale completion log includes elapsed duration
+
+When a background scale operation completes successfully, the autoscaler SHALL emit an informational log that states the operation completed successfully and includes the elapsed time from the start of that apply until completion, formatted as `HH:mm:ss`, where the first segment is the total whole number of hours in the elapsed span (not a 24-hour clock).
+
+#### Scenario: Apply finishes after measurable elapsed time
+
+- **WHEN** a background scale apply starts and later completes without error
+- **THEN** the success log line MUST include a duration string matching the pattern `H+:MM:SS` (one or more hour digits, two-digit minutes, two-digit seconds) derived from UTC elapsed time between apply start and apply completion
+
+#### Scenario: Apply spans more than twenty-four hours
+
+- **WHEN** the elapsed time between apply start and completion is 25 hours or more
+- **THEN** the hour segment of the duration string MUST reflect total hours (e.g. `25:00:00` for twenty-five hours), not a value that wraps within 0–23

--- a/readme.md
+++ b/readme.md
@@ -594,6 +594,69 @@ Resource expansion works for:
 * SQL Databases in an Azure SQL Server
 * SQL Elastic Pools in an Azure SQL Server
 
+### Resource Filter
+
+When using wildcard expansion, you can narrow down the discovered resources using `ResourceFilter` — an optional C# lambda expression compiled at startup. Only resources for which the expression returns `true` are added to the autoscaler's resource set. Resources with a literal (non-wildcard) `ResourceId` are never filtered.
+
+The lambda receives a `ResourceFilterContext` parameter with the following properties:
+
+| Property | Type | Description |
+|---|---|---|
+| `ResourceName` | `string` | The name of the expanded resource (database name, pool name, etc.) |
+| `Tags` | `IDictionary<string, string>` | Azure tags on the resource at expansion time |
+| `Resource` | `object` | The raw ARM resource object — Dynamic LINQ resolves members against the actual runtime type at runtime |
+
+Access resource-type-specific properties directly via `r.Resource` — the same pattern already used in `DataExpression` for custom metrics (e.g. `data.Resource.Data.Sku.Name`).
+
+#### Azure SQL Database SKU reference
+
+When filtering SQL databases expanded from a `databases/*` wildcard, the `Sku.Name` value identifies the database model:
+
+| `Sku.Name` | Model | `Sku.Family` | Notes |
+|---|---|---|---|
+| `Basic` | DTU | `null` | 5 DTU fixed |
+| `Standard` | DTU | `null` | S0–S9 |
+| `Premium` | DTU | `null` | P1–P15 |
+| `ElasticPool` | DTU (pooled) | `null` | Member of an elastic pool — uses pool-level metrics, not per-database DTU |
+| `GeneralPurpose` | vCore | non-null (e.g. `Gen5`) | GP_Gen5_2, GP_Fsv2_8, GP_DC_2, … |
+| `BusinessCritical` | vCore | non-null | BC_Gen5_4, … |
+| `Hyperscale` | vCore | non-null | HS_Gen5_4, … |
+
+**Example — standalone DTU SQL databases only** (`Basic`, `Standard`, `Premium`; excludes elastic-pool members and vCore):
+
+```yaml
+  - Resources:
+      sql_dtu_databases:
+        ResourceId: "/subscriptions/.../servers/mysqlserver/databases/*"
+        ResourceFilter: "(r) => r.Resource.Data.Sku.Name == \"Basic\" || r.Resource.Data.Sku.Name == \"Standard\" || r.Resource.Data.Sku.Name == \"Premium\""
+```
+
+**Example — vCore databases only** (excludes all DTU tiers and elastic-pool members):
+
+```yaml
+  - Resources:
+      sql_vcore_databases:
+        ResourceId: "/subscriptions/.../servers/mysqlserver/databases/*"
+        ResourceFilter: "(r) => r.Resource.Data.Sku.Family != null"
+```
+
+**Example — tag-based filtering** (only databases tagged `env=prod`):
+
+```yaml
+  - Resources:
+      sql_prod_databases:
+        ResourceId: "/subscriptions/.../servers/mysqlserver/databases/*"
+        ResourceFilter: "(r) => r.Tags.ContainsKey(\"env\") && r.Tags[\"env\"] == \"prod\""
+```
+
+After expansion the autoscaler logs a summary at `Information` level for each resource instance with a filter set:
+
+```
+ResourceFilter 'sql_dtu_databases': 8 discovered, 3 filtered out, 5 added.
+```
+
+> **Note:** If the expression fails to compile (e.g. references a non-existent property), startup fails immediately with a descriptive error. Invalid filters are never silently ignored.
+
 ### Resource Tags
 
 Azure Autoscaler reads tags from resources and makes them available in the `ResourceTags` dictionary for each resource. Tags can be used to control resource behavior.


### PR DESCRIPTION
## Resource instance filter — declarative lambda filtering for wildcard-expanded resources

### Problem

When a `ResourceId` uses a wildcard (e.g. `databases/*`) the autoscaler expands it and runs every discovered resource through the same scaling loop. SQL servers often host a mix of SKU models — DTU standalone (`Basic`, `Standard`, `Premium`), elastic-pool members (`ElasticPool`), and vCore databases (`GeneralPurpose`, `BusinessCritical`, `Hyperscale`) — but metrics are model-specific. Requesting `dtu_consumption_percent` against a vCore database returns a `400 Bad Request` from Azure Monitor, which disables the resource for an hour. There was no config-level mechanism to express "only apply this block to databases of a given type"; operators had to list resources explicitly or rely on silent internal filtering invisible in the YAML.

### Solution

A new optional `ResourceFilter` property on `ResourceInstance` accepts a C# lambda expression that is compiled at startup and evaluated during resource discovery, before any scaling work begins.

```yaml
Resources:
  sql_dtu_databases:
    ResourceId: ".../servers/mysqlserver/databases/*"
    ResourceFilter: "(r) => r.Resource.Data.Sku.Name == \"Basic\" || r.Resource.Data.Sku.Name == \"Standard\" || r.Resource.Data.Sku.Name == \"Premium\""
```

The lambda receives a `ResourceFilterContext` with three properties:

| Property | Type | Description |
|---|---|---|
| `ResourceName` | `string` | Name of the expanded resource |
| `Tags` | `IDictionary<string, string>` | Azure resource tags at expansion time |
| `Resource` | `object` | Raw ARM resource object — Dynamic LINQ resolves members at runtime, same as `DataExpression` |

### Changes

- **`configuration/ResourceFilterContext.cs`** — new lean context class
- **`resourcemanagement/Dto/ExpandedResource.cs`** — new DTO that pairs a resolved resource ID with its filter context
- **`ResourceInstance`** — new `ResourceFilter` (string) + `ResourceFilterExpression` (`Func<ResourceFilterContext, bool>?`) properties
- **`Configuration.PrepareAndValidate`** — compiles the lambda at startup via `ExpressionParserUtils`; fails fast with a descriptive error if the expression is invalid
- **`IResourceStateFactory` / `ResourceStateFactory`** — `ExpandResourcesAsync` return type changed from `Dictionary<string, string>` to `Dictionary<string, ExpandedResource>`
- **All four expansion helpers** (`MsSqlDatabase`, `MssqlElasticPool`, `AksNodePool`, `StorageFileShare`) — now populate and return the `ResourceFilterContext` alongside each expanded resource ID
- **`ResourceManager.DiscoverCoreAsync`** — centralized filtering with a per-`ResourceInstance` summary log: `ResourceFilter 'key': N discovered, M filtered out, K added.`
- **`MyCustomTypeProvider`** — `ResourceFilterContext` registered for Dynamic LINQ resolution
- **Tests** — `ConfigurationResourceFilterTests` (5 cases) + `ResourceManagerTests` (4 cases); all 355 suite tests pass
- **Docs** — `readme.md` updated with SKU reference table and examples; `config.yml.example` annotated

### No breaking changes

`ResourceFilter` is optional. Configs without it behave identically — literal (non-wildcard) resource IDs are never filtered regardless of whether a filter is set.
